### PR TITLE
fix: correct compilation error due to warning in cast to UnityFuncPtr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC := x86_64-w64-mingw32-gcc
-CFLAGS := -std=c99 -pedantic -Wall -Wextra -Werror -municode
+CFLAGS := -std=c99 -pedantic -Wall -Wextra -Werror -Wno-cast-function-type -municode
 
 SRC := src/patch.c
 TARGET := build/patch.exe


### PR DESCRIPTION
When trying to compile the patch with `make` (or generally compiling with Mingw and the `-Wextra` and `-Werror` flags at the same time), the following error occurs:

```
src/patch.c: In function ‘wWinMain’:
src/patch.c:31:30: error: cast between incompatible function types from ‘FARPROC’ {aka ‘long long int (*)()’} to ‘int (*)(struct HINSTANCE__ *, struct HINSTANCE__ *, WCHAR *, int)’ {aka ‘int (*)(struct HINSTANCE__ *, struct HINSTANCE__ *, short unsigned int *, int)’} [-Werror=cast-function-type]
   31 |     UnityFuncPtr UnityMain = (UnityFuncPtr)GetProcAddress(unityDll, UNITY_MAIN_FUNC);
      |                              ^
cc1: all warnings being treated as errors
```

It is caused by the `-Wextra` flag generating the `cast-function-type` warning which is then caught by the `-Werror` flag, and as a result compilation fails.

If I understood correctly, this warning is caused by `GetProcAddress` returning a `FARPROC` pointer to a function and mingw's/windows headers using `long long int (*)()` as a generic "any function" return value, while `UnityFuncPtr` is defined as `int (*UnityFuncPtr)(HINSTANCE, HINSTANCE, LPWSTR, int)`.

However, the current implementation seems to be correct and expected, as `FARPROC` is defined as `INT_PTR (WINAPI *FARPROC)(void)` on windows 64 bit, and the compiler gives a warning because it doesn't know that the return value of `GetProcAddress` is expected to be cast.

As such, it seems to be safe and the warning should be ignored (for example, see https://github.com/boostorg/thread/issues/225#issuecomment-410699705)

To do this, I used `#pragma` to ignore the warning for that specific line only. That said, I am not really knowledgeable about C, so please correct me if I there's something wrong or a better way to fix the issue.